### PR TITLE
Add X-Pplx-Integration attribution header to API requests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -124,11 +124,13 @@ describe("Perplexity MCP Server", () => {
         AGENT_URL,
         expect.objectContaining({
           method: "POST",
-          headers: expect.objectContaining({
+          headers: {
             "Content-Type": "application/json",
             Authorization: "Bearer test-api-key",
+            "User-Agent": "perplexity-mcp/1.2.0",
             "X-Source": "pplx-mcp-server",
-          }),
+            "X-Pplx-Integration": "perplexity-mcp/1.2.0",
+          },
           body: JSON.stringify({
             preset: "fast",
             input: [{ type: "message", role: "user", content: "test question" }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,6 +111,7 @@ async function makeApiRequest(
       "Authorization": `Bearer ${resolvedApiKey}`,
       "User-Agent": `perplexity-mcp/${VERSION}`,
       "X-Source": "pplx-mcp-server",
+      "X-Pplx-Integration": `perplexity-mcp/${VERSION}`,
     };
     if (serviceOrigin) {
       headers["X-Service"] = serviceOrigin;


### PR DESCRIPTION
## Summary

Perplexity logs the opt-in `X-Pplx-Integration` header at API ingress for integration attribution. This adds `X-Pplx-Integration: perplexity-mcp/<version>` to every outbound API request using the existing MCP server version, with no behavior change.

## Outbound headers

- `Content-Type: application/json`
- `Authorization: Bearer <API key>`
- `User-Agent: perplexity-mcp/<version>`
- `X-Source: pplx-mcp-server`
- `X-Pplx-Integration: perplexity-mcp/<version>` (new)
- `X-Service: <service origin>` when a service origin is provided

## Verification

- `npm test` (89 tests passed)
- `npm run build`
- No lint script is defined in `package.json`
