### PR TITLE
Add X-Pplx-Integration attribution header to API requests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -124,11 +124,13 @@ describe("Perplexity MCP Server", () => {
         AGENT_URL,
         expect.objectContaining({
           method: "POST",
-          headers: expect.objectContaining({
+          headers: {
             "Content-Type": "application/json",
             Authorization: "Bearer test-api-key",
+            "User-Agent": "perplexity-mcp/1.2.0",
             "X-Source": "pplx-mcp-server",
-          }),
+            "X-Pplx-Integration": "perplexity-mcp/1.2.0",
+          },
           body: JSON.stringify({
             preset: "fast",
             input: [{ type: "message", role: "user", content: "test question" }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,6 +111,7 @@ async function makeApiRequest(
       "Authorization": `Bearer ${resolvedApiKey}`,
       "User-Agent": `perplexity-mcp/${VERSION}`,
       "X-Source": "pplx-mcp-server",
+      "X-Pplx-Integration": `perplexity-mcp/${VERSION}`,
     };
     if (serviceOrigin) {
       headers["X-Service"] = serviceOrigin;


### PR DESCRIPTION
## Summary

Perplexity now records the opt-in `X-Pplx-Integration` header at API ingress. This adds `X-Pplx-Integration: perplexity-mcp/<version>` to the MCP server's shared outbound request headers, alongside its existing user agent and source headers.

All MCP tools use the shared request path, and API behavior is otherwise unchanged.

## Verification

- The request-boundary test asserts the complete outbound header set, including the versioned integration value.
- The MCP server test suite passes all 89 tests, and the package builds successfully.
- Preview and main comparison: n/a because this is a published MCP client header change with no deployable preview surface.
