### PR TITLE
fix: advertise JSON Schema 2020-12 in tools/list

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Perplexity AI plugin providing real-time web search, reasoning, and research capabilities",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "plugins": [
     {
       "name": "perplexity",
       "source": "./",
       "description": "Real-time web search, reasoning, and research through Perplexity's API",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Perplexity AI",
         "email": "api@perplexity.ai"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@perplexity-ai/mcp-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@perplexity-ai/mcp-server",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perplexity-ai/mcp-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "mcpName": "ai.perplexity/mcp-server",
   "description": "Real-time web search, reasoning, and research through Perplexity's API",
   "keywords": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "perplexity",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Real-time web search, reasoning, and research through Perplexity's API",
   "author": {
     "name": "Perplexity AI",

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "ai.perplexity/mcp-server",
   "title": "Perplexity API Platform",
   "description": "Real-time web search, reasoning, and research through Perplexity's API",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@perplexity-ai/mcp-server",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -127,9 +127,9 @@ describe("Perplexity MCP Server", () => {
           headers: {
             "Content-Type": "application/json",
             Authorization: "Bearer test-api-key",
-            "User-Agent": "perplexity-mcp/1.2.0",
+            "User-Agent": "perplexity-mcp/1.2.1",
             "X-Source": "pplx-mcp-server",
-            "X-Pplx-Integration": "perplexity-mcp/1.2.0",
+            "X-Pplx-Integration": "perplexity-mcp/1.2.1",
           },
           body: JSON.stringify({
             preset: "fast",

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -366,3 +366,31 @@ describe("Server Utility Functions", () => {
     });
   });
 });
+
+describe("createPerplexityServer tools/list schemas", () => {
+  it("advertises JSON Schema 2020-12 on every input and output schema", async () => {
+    vi.stubEnv("PERPLEXITY_API_KEY", "pplx-test");
+    const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+    const { InMemoryTransport } = await import("@modelcontextprotocol/sdk/inMemory.js");
+    const { createPerplexityServer } = await import("./server.js");
+
+    const server = createPerplexityServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await client.connect(clientTransport);
+
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+    for (const tool of tools) {
+      expect(tool.inputSchema.$schema, `${tool.name} inputSchema`).toBe(
+        "https://json-schema.org/draft/2020-12/schema"
+      );
+      expect(tool.outputSchema?.$schema, `${tool.name} outputSchema`).toBe(
+        "https://json-schema.org/draft/2020-12/schema"
+      );
+    }
+    await client.close();
+    await server.close();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export type { ApiKeyProvider, PerplexityServerOptions } from "./types.js";
 
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
 const PERPLEXITY_BASE_URL = process.env.PERPLEXITY_BASE_URL || "https://api.perplexity.ai";
-const VERSION = "1.2.0";
+const VERSION = "1.2.1";
 
 // Agent API presets backing each tool: https://docs.perplexity.ai/docs/agent-api/presets
 export const ASK_PRESET = "fast";
@@ -776,5 +776,45 @@ export function createPerplexityServer(serviceOrigin?: string, serverOptions?: P
     }
   );
 
+  advertiseJsonSchema202012(server.server);
+
   return server.server;
+}
+
+// The MCP TypeScript SDK stamps draft-07 on zod-derived schemas in tools/list
+// (modelcontextprotocol/typescript-sdk#2084), and 2020-12-only clients reject
+// every tool before invocation. Our schemas are valid under both dialects, so
+// only the declared dialect needs rewriting; this mirrors what the upstream
+// fix (typescript-sdk#2085) does for zod v3 schemas. Remove once that fix is
+// released and the SDK dependency is bumped past it.
+const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+function advertiseJsonSchema202012(server: McpServer["server"]) {
+  type ListToolsHandler = (request: unknown, extra: unknown) => Promise<{
+    tools: Array<{
+      inputSchema?: { $schema?: string };
+      outputSchema?: { $schema?: string };
+    }>;
+  }>;
+  // _requestHandlers is private; acceptable here because this shim is
+  // temporary and pinned to the SDK versions we test against.
+  const handlers = (server as unknown as {
+    _requestHandlers: Map<string, ListToolsHandler>;
+  })._requestHandlers;
+  const listTools = handlers.get("tools/list");
+  if (!listTools) {
+    return;
+  }
+  handlers.set("tools/list", async (request, extra) => {
+    const result = await listTools(request, extra);
+    for (const tool of result.tools ?? []) {
+      if (tool.inputSchema?.$schema) {
+        tool.inputSchema.$schema = JSON_SCHEMA_2020_12;
+      }
+      if (tool.outputSchema?.$schema) {
+        tool.outputSchema.$schema = JSON_SCHEMA_2020_12;
+      }
+    }
+    return result;
+  });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -781,12 +781,10 @@ export function createPerplexityServer(serviceOrigin?: string, serverOptions?: P
   return server.server;
 }
 
-// The MCP TypeScript SDK stamps draft-07 on zod-derived schemas in tools/list
-// (modelcontextprotocol/typescript-sdk#2084), and 2020-12-only clients reject
-// every tool before invocation. Our schemas are valid under both dialects, so
-// only the declared dialect needs rewriting; this mirrors what the upstream
-// fix (typescript-sdk#2085) does for zod v3 schemas. Remove once that fix is
-// released and the SDK dependency is bumped past it.
+// The MCP TypeScript SDK stamps draft-07 on tools/list schemas
+// (modelcontextprotocol/typescript-sdk#2084); 2020-12-only clients reject
+// them. The schemas are valid under both dialects, so only the declared
+// dialect needs rewriting. Remove once typescript-sdk#2085 ships.
 const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
 
 function advertiseJsonSchema202012(server: McpServer["server"]) {
@@ -796,8 +794,7 @@ function advertiseJsonSchema202012(server: McpServer["server"]) {
       outputSchema?: { $schema?: string };
     }>;
   }>;
-  // _requestHandlers is private; acceptable here because this shim is
-  // temporary and pinned to the SDK versions we test against.
+  // _requestHandlers is private SDK state; goes away with this shim.
   const handlers = (server as unknown as {
     _requestHandlers: Map<string, ListToolsHandler>;
   })._requestHandlers;


### PR DESCRIPTION
Fixes #132.

## Problem

`tools/list` advertises `$schema: http://json-schema.org/draft-07/schema#` on every input and output schema. Clients that only support JSON Schema 2020-12 (the dialect the MCP spec specifies) reject all 8 schemas before any tool is invoked, so every tool is unusable in those clients.

Root cause is in the MCP TypeScript SDK: the zod v3 conversion path never sets a dialect target, so `zod-to-json-schema` defaults to draft-07 (modelcontextprotocol/typescript-sdk#2084). The upstream fix (modelcontextprotocol/typescript-sdk#2085) is not merged or released yet, so this patches it on our side.

## Fix

The schemas themselves are valid under both dialects (verified with a strict Ajv 2020-12 validator: 8/8 rejected as-is, 8/8 compile after changing only the `$schema` string; no draft-07-only constructs present). So `createPerplexityServer` now wraps the SDK's `tools/list` handler and rewrites the declared dialect to 2020-12. This mirrors what the upstream fix does for zod v3 schemas. The shim touches a private SDK field and is meant to be removed once the SDK fix ships and we bump past it.

Version goes to 1.2.1 so the fix publishes on merge.

## Verification

- New test: in-memory client calls `tools/list` and asserts 2020-12 on all input and output schemas. Fails without the fix, passes with it.
- Full suite: 90/90 passing, `npm run build` clean.
- Manually confirmed against a strict 2020-12-only Ajv validator: all 8 schemas compile after the fix.
