### PR TITLE
ci: pin and verify MCP publisher artifact

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -13,21 +13,28 @@ jobs:
       name: production
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      
+
       - name: Install MCP Publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
-      
+          archive=mcp-publisher_linux_amd64.tar.gz
+          curl --fail --location --silent --show-error \
+            --output "$archive" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${archive}"
+          echo "${MCP_PUBLISHER_SHA256}  ${archive}" | sha256sum --check
+          tar --extract --gzip --file "$archive" mcp-publisher
+
       - name: Login to MCP Registry
         run: |
           echo "${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}" > key.pem
           ./mcp-publisher login dns --domain perplexity.ai --private-key "$(openssl pkey -in key.pem -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')"
           rm key.pem
-      
+
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
-


### PR DESCRIPTION
## Why

The MCP registry publish workflow downloads and executes the moving upstream `latest` publisher artifact in the same job that receives `MCP_REGISTRY_PRIVATE_KEY`. Production environment approval limits when the job runs, but it does not verify which publisher binary receives that key. This creates a concrete registry-publication and credential-exposure path if the upstream publisher release channel is compromised.

## What changed

- Pin the publisher download to upstream release `v1.8.1` and its Linux amd64 asset.
- Verify the independently checked SHA-256 before extracting or executing the publisher.
- Fail downloads explicitly while preserving the existing production environment gate.

This is intentionally scoped to MCP registry publication. The separate npm OIDC/provenance workflow and other CLI release chains are unchanged.

## Verification evidence

The pinned digest `a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc` agrees across the upstream checksum file, GitHub's release-asset digest, and an independently downloaded v1.8.1 archive. The verification command accepts that archive and rejects a mismatched digest before extraction.

## Review

MCP release owners: @rbuchmayer-pplx and @kesku.
